### PR TITLE
fix: correct type annotation for _safe_call func parameter

### DIFF
--- a/src/robinhood_mcp/tools.py
+++ b/src/robinhood_mcp/tools.py
@@ -1,5 +1,6 @@
 """Read-only Robinhood tools wrapping robin_stocks library."""
 
+from collections.abc import Callable
 from typing import Any, Literal
 
 import robin_stocks.robinhood as rh
@@ -11,7 +12,7 @@ class RobinhoodError(Exception):
     pass
 
 
-def _safe_call(func: callable, *args, **kwargs) -> Any:
+def _safe_call(func: Callable[..., Any], *args, **kwargs) -> Any:
     """Safely call a robin_stocks function with error handling.
 
     Args:


### PR DESCRIPTION
## Summary

- `callable` (lowercase) is a builtin function, not a type annotation
- Changed to `Callable[..., Any]` from `collections.abc` for proper static analysis support

This also serves as the first conventional `fix:` commit to kick off release-please — it'll create a Release PR after merge with a `0.1.1` patch bump.

## Test plan

- [x] `ruff check` passes
- [x] `pytest` — 35 passed


Made with [Cursor](https://cursor.com)