### PR TITLE
fix: harden push approval auth flow

### DIFF
--- a/src/robinhood_mcp/auth.py
+++ b/src/robinhood_mcp/auth.py
@@ -112,12 +112,19 @@ def _patched_validate_sherrif_id(
         if not isinstance(resp, dict):
             raise AuthenticationError("TOTP challenge response was empty")
         if resp.get("status") == "validated":
-            result = _request_workflow_result(inquiries_url)
-            if result == "workflow_status_approved":
-                return
-            if not result:
-                raise AuthenticationError("TOTP validated but workflow result was empty")
-            raise AuthenticationError(f"TOTP validated but workflow not approved: {result}")
+            # Retry workflow finalization — the workflow may not be immediately
+            # ready after TOTP validation (same race the push-approval path handles).
+            totp_start = time.time()
+            while time.time() - totp_start < 120:
+                result = _request_workflow_result(inquiries_url)
+                if result == "workflow_status_approved":
+                    return
+                if result:
+                    raise AuthenticationError(f"TOTP validated but workflow not approved: {result}")
+                time.sleep(5)
+            raise AuthenticationError(
+                "TOTP validated but workflow finalization timed out after 2 minutes"
+            )
 
     # Poll for mobile app approval
     prompts_url = f"https://api.robinhood.com/push/{challenge_id}/get_prompts_status/"
@@ -270,9 +277,7 @@ def login(
         if not result:
             if is_logged_in():
                 return {
-                    "detail": (
-                        "logged in with active Robinhood session after empty login result"
-                    ),
+                    "detail": ("logged in with active Robinhood session after empty login result"),
                     "recovered_empty_result": True,
                     "session_valid": True,
                 }

--- a/src/robinhood_mcp/auth.py
+++ b/src/robinhood_mcp/auth.py
@@ -15,10 +15,12 @@ sends a push notification and waits for mobile app approval.
 """
 
 import inspect
+import io
 import logging
 import os
 import sys
 import time
+from contextlib import redirect_stdout
 from typing import Any
 
 import pyotp
@@ -48,6 +50,25 @@ class EnvironmentVariablesError(AuthenticationError):
 # ---------------------------------------------------------------------------
 
 
+def _dict_or_empty(value: Any) -> dict[str, Any]:
+    """Normalize optional Robinhood payload fragments to dictionaries."""
+    return value if isinstance(value, dict) else {}
+
+
+def _request_workflow_result(inquiries_url: str) -> str | None:
+    """Ask Robinhood whether an approved challenge has finalized the workflow."""
+    inq_resp = request_post(
+        url=inquiries_url,
+        payload={"sequence": 0, "user_input": {"status": "continue"}},
+        json=True,
+    )
+    if not isinstance(inq_resp, dict):
+        return None
+    context = _dict_or_empty(inq_resp.get("context"))
+    type_context = _dict_or_empty(inq_resp.get("type_context"))
+    return context.get("result") or type_context.get("result", "")
+
+
 def _patched_validate_sherrif_id(
     device_token: str, workflow_id: str, mfa_code: str | None = None
 ) -> None:
@@ -64,15 +85,19 @@ def _patched_validate_sherrif_id(
     }
     data = request_post(url=user_machine_url, payload=payload, json=True)
 
-    if "id" not in data:
+    if not isinstance(data, dict) or "id" not in data:
         raise AuthenticationError("Verification workflow failed — missing inquiry ID")
 
     inquiries_url = f"https://api.robinhood.com/pathfinder/inquiries/{data['id']}/user_view/"
     res = request_get(inquiries_url)
+    if not isinstance(res, dict):
+        raise AuthenticationError("Verification workflow failed — missing inquiry details")
 
     # API changed key from type_context.context → context
-    ctx = res.get("context") or res.get("type_context", {}).get("context", {})
-    challenge_id = ctx.get("sheriff_challenge", {}).get("id") if isinstance(ctx, dict) else None
+    ctx = _dict_or_empty(res.get("context"))
+    if not ctx:
+        ctx = _dict_or_empty(_dict_or_empty(res.get("type_context")).get("context"))
+    challenge_id = _dict_or_empty(ctx.get("sheriff_challenge")).get("id")
     if not challenge_id:
         inquiry_id = data.get("id")
         details = f" for inquiry {inquiry_id}" if inquiry_id else ""
@@ -84,17 +109,14 @@ def _patched_validate_sherrif_id(
     if mfa_code:
         challenge_url = f"https://api.robinhood.com/challenge/{challenge_id}/respond/"
         resp = request_post(url=challenge_url, payload={"response": mfa_code}, json=True)
+        if not isinstance(resp, dict):
+            raise AuthenticationError("TOTP challenge response was empty")
         if resp.get("status") == "validated":
-            inq_resp = request_post(
-                url=inquiries_url,
-                payload={"sequence": 0, "user_input": {"status": "continue"}},
-                json=True,
-            )
-            result = inq_resp.get("context", {}).get("result") or inq_resp.get(
-                "type_context", {}
-            ).get("result", "")
+            result = _request_workflow_result(inquiries_url)
             if result == "workflow_status_approved":
                 return
+            if not result:
+                raise AuthenticationError("TOTP validated but workflow result was empty")
             raise AuthenticationError(f"TOTP validated but workflow not approved: {result}")
 
     # Poll for mobile app approval
@@ -109,20 +131,26 @@ def _patched_validate_sherrif_id(
     while time.time() - start < 120:
         time.sleep(5)
         status_res = request_get(url=prompts_url)
-        if status_res.get("challenge_status") == "validated":
-            inq_resp = request_post(
-                url=inquiries_url,
-                payload={"sequence": 0, "user_input": {"status": "continue"}},
-                json=True,
+        elapsed = int(time.time() - start)
+        if not isinstance(status_res, dict):
+            print(
+                f"[robinhood-mcp] Approval status unavailable, retrying... ({elapsed}s)",
+                file=sys.stderr,
             )
-            result = inq_resp.get("context", {}).get("result") or inq_resp.get(
-                "type_context", {}
-            ).get("result", "")
+            continue
+        if status_res.get("challenge_status") == "validated":
+            result = _request_workflow_result(inquiries_url)
             if result == "workflow_status_approved":
                 print("[robinhood-mcp] Login approved!", file=sys.stderr)
                 return
+            if not result:
+                print(
+                    "[robinhood-mcp] Approval recorded, waiting for workflow "
+                    f"finalization... ({elapsed}s)",
+                    file=sys.stderr,
+                )
+                continue
             raise AuthenticationError(f"Challenge validated but workflow not approved: {result}")
-        elapsed = int(time.time() - start)
         print(f"[robinhood-mcp] Waiting for approval... ({elapsed}s)", file=sys.stderr)
 
     raise AuthenticationError("Login timed out after 2 minutes. Restart server and approve in app.")
@@ -176,6 +204,31 @@ def _clear_stale_pickle() -> None:
             raise
 
 
+def _emit_captured_login_stdout(output: str) -> None:
+    """Forward robin_stocks stdout chatter to stderr for MCP-safe logging."""
+    for raw_line in output.splitlines():
+        line = raw_line.strip()
+        if line:
+            print(f"[robinhood-mcp][robin_stocks] {line}", file=sys.stderr)
+
+
+def _login_with_captured_stdout(
+    *, username: str, password: str, mfa_code: str | None
+) -> dict[str, Any] | None:
+    """Run robin_stocks login without letting stdout corrupt MCP JSON-RPC transport."""
+    stdout_buffer = io.StringIO()
+    try:
+        with redirect_stdout(stdout_buffer):
+            return rh.login(
+                username=username,
+                password=password,
+                mfa_code=mfa_code,
+                store_session=True,
+            )
+    finally:
+        _emit_captured_login_stdout(stdout_buffer.getvalue())
+
+
 def login(
     username: str | None = None,
     password: str | None = None,
@@ -208,14 +261,21 @@ def login(
     mfa_code = get_totp_code(totp_secret)
 
     try:
-        result = rh.login(
+        result = _login_with_captured_stdout(
             username=username,
             password=password,
             mfa_code=mfa_code,
-            store_session=True,
         )
 
         if not result:
+            if is_logged_in():
+                return {
+                    "detail": (
+                        "logged in with active Robinhood session after empty login result"
+                    ),
+                    "recovered_empty_result": True,
+                    "session_valid": True,
+                }
             raise AuthenticationError("Login returned empty result")
 
         return result

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -7,6 +7,7 @@ import pytest
 from robinhood_mcp.auth import (
     AuthenticationError,
     _clear_stale_pickle,
+    _patched_validate_sherrif_id,
     get_totp_code,
     is_logged_in,
     login,
@@ -88,6 +89,84 @@ class TestLogin:
         call_args = mock_login.call_args
         assert call_args.kwargs["mfa_code"] is not None
         assert len(call_args.kwargs["mfa_code"]) == 6
+
+    @patch.dict(
+        "os.environ",
+        {"ROBINHOOD_USERNAME": "test@example.com", "ROBINHOOD_PASSWORD": "secret"},
+        clear=True,
+    )
+    @patch("robinhood_mcp.auth._clear_stale_pickle")
+    @patch("robinhood_mcp.auth.is_logged_in")
+    @patch("robinhood_mcp.auth.rh.login")
+    def test_treats_empty_result_as_success_when_session_is_valid(
+        self,
+        mock_login: MagicMock,
+        mock_is_logged_in: MagicMock,
+        mock_clear_stale_pickle: MagicMock,
+    ):
+        """Should recover when robin_stocks returns no payload but session is valid."""
+        mock_login.return_value = None
+        mock_is_logged_in.return_value = True
+
+        result = login()
+
+        assert result["recovered_empty_result"] is True
+        assert result["session_valid"] is True
+        assert "active Robinhood session" in result["detail"]
+        mock_clear_stale_pickle.assert_not_called()
+
+    @patch.dict(
+        "os.environ",
+        {"ROBINHOOD_USERNAME": "test@example.com", "ROBINHOOD_PASSWORD": "secret"},
+        clear=True,
+    )
+    @patch("robinhood_mcp.auth._clear_stale_pickle")
+    @patch("robinhood_mcp.auth.is_logged_in")
+    @patch("robinhood_mcp.auth.rh.login")
+    def test_raises_on_empty_result_without_valid_session(
+        self,
+        mock_login: MagicMock,
+        mock_is_logged_in: MagicMock,
+        mock_clear_stale_pickle: MagicMock,
+    ):
+        """Should still raise when robin_stocks returns no payload and no session exists."""
+        mock_login.return_value = None
+        mock_is_logged_in.return_value = False
+
+        with pytest.raises(AuthenticationError) as exc_info:
+            login()
+
+        assert "empty result" in str(exc_info.value)
+        mock_clear_stale_pickle.assert_called_once()
+
+    @patch.dict(
+        "os.environ",
+        {"ROBINHOOD_USERNAME": "test@example.com", "ROBINHOOD_PASSWORD": "secret"},
+        clear=True,
+    )
+    @patch("robinhood_mcp.auth.rh.login")
+    def test_redirects_robin_stocks_stdout_to_stderr(
+        self, mock_login: MagicMock, capsys: pytest.CaptureFixture[str]
+    ):
+        """Should keep third-party login chatter off stdout for MCP safety."""
+
+        def fake_login(**_: str) -> dict[str, str]:
+            print("Starting login process...")
+            print("Verification required, handling challenge...")
+            return {"access_token": "test"}
+
+        mock_login.side_effect = fake_login
+
+        result = login()
+        captured = capsys.readouterr()
+
+        assert result == {"access_token": "test"}
+        assert captured.out == ""
+        assert "[robinhood-mcp][robin_stocks] Starting login process..." in captured.err
+        assert (
+            "[robinhood-mcp][robin_stocks] Verification required, handling challenge..."
+            in captured.err
+        )
 
     @patch.dict(
         "os.environ",
@@ -180,6 +259,90 @@ class TestLogout:
 
         # Should not raise
         logout()
+
+
+class TestPatchedValidationWorkflow:
+    """Tests for the patched Robinhood verification workflow."""
+
+    @patch("robinhood_mcp.auth.time.sleep", return_value=None)
+    @patch("robinhood_mcp.auth.time.time", side_effect=range(0, 500, 5))
+    @patch("robinhood_mcp.auth.request_get")
+    @patch("robinhood_mcp.auth.request_post")
+    def test_retries_when_prompt_status_response_is_empty(
+        self,
+        mock_request_post: MagicMock,
+        mock_request_get: MagicMock,
+        _mock_time: MagicMock,
+        _mock_sleep: MagicMock,
+    ):
+        """Should keep polling when prompt status endpoint briefly returns None."""
+        mock_request_post.side_effect = [
+            {"id": "inq-123"},
+            {"context": {"result": "workflow_status_approved"}},
+        ]
+        mock_request_get.side_effect = [
+            {"context": {"sheriff_challenge": {"id": "challenge-123"}}},
+            None,
+            {"challenge_status": "validated"},
+        ]
+
+        _patched_validate_sherrif_id("device-token", "workflow-id")
+
+        assert mock_request_get.call_count == 3
+
+    @patch("robinhood_mcp.auth.time.sleep", return_value=None)
+    @patch("robinhood_mcp.auth.time.time", side_effect=range(0, 500, 5))
+    @patch("robinhood_mcp.auth.request_get")
+    @patch("robinhood_mcp.auth.request_post")
+    def test_retries_when_workflow_result_is_empty_after_approval(
+        self,
+        mock_request_post: MagicMock,
+        mock_request_get: MagicMock,
+        _mock_time: MagicMock,
+        _mock_sleep: MagicMock,
+    ):
+        """Should keep polling when approval is recorded before workflow result is ready."""
+        mock_request_post.side_effect = [
+            {"id": "inq-123"},
+            None,
+            {"context": {"result": "workflow_status_approved"}},
+        ]
+        mock_request_get.side_effect = [
+            {"context": {"sheriff_challenge": {"id": "challenge-123"}}},
+            {"challenge_status": "validated"},
+            {"challenge_status": "validated"},
+        ]
+
+        _patched_validate_sherrif_id("device-token", "workflow-id")
+
+        assert mock_request_post.call_count == 3
+
+    @patch("robinhood_mcp.auth.time.sleep", return_value=None)
+    @patch("robinhood_mcp.auth.time.time", side_effect=range(0, 500, 5))
+    @patch("robinhood_mcp.auth.request_get")
+    @patch("robinhood_mcp.auth.request_post")
+    def test_retries_when_workflow_context_is_null_after_approval(
+        self,
+        mock_request_post: MagicMock,
+        mock_request_get: MagicMock,
+        _mock_time: MagicMock,
+        _mock_sleep: MagicMock,
+    ):
+        """Should tolerate Robinhood returning {'context': None} before finalization."""
+        mock_request_post.side_effect = [
+            {"id": "inq-123"},
+            {"context": None, "type_context": None},
+            {"context": {"result": "workflow_status_approved"}},
+        ]
+        mock_request_get.side_effect = [
+            {"context": {"sheriff_challenge": {"id": "challenge-123"}}},
+            {"challenge_status": "validated"},
+            {"challenge_status": "validated"},
+        ]
+
+        _patched_validate_sherrif_id("device-token", "workflow-id")
+
+        assert mock_request_post.call_count == 3
 
 
 class TestIsLoggedIn:


### PR DESCRIPTION
## Summary
- capture `robin_stocks` login stdout and forward it to stderr so MCP stdio stays clean
- recover from empty `rh.login()` results when Robinhood has already established a valid session
- harden push-approval workflow polling against transient `None` and `context: null` responses during approval finalization

## Verification
- `uv run pytest -q`
- `uv run ruff check`
- end-to-end from `autohub` via `mcpClient.callTool('robinhood', 'robinhood_get_portfolio', {})`

## End-to-end result
Phone approval completed successfully and the tool returned a non-error portfolio payload from `autohub`.

```text
[robinhood-mcp] Login approved!
[robinhood-mcp] Logged in to Robinhood
Tool result ... "isError": false
```

## Follow-up
The remaining shutdown validation warnings are a hub-side teardown issue: `autohub` sends `shutdown` to FastMCP servers that do not implement that method. I left that out of this PR because it belongs in `autohub`, not `robinhood-mcp`.
