### PR TITLE
ci: enforce conventional PR titles

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,35 @@
+name: PR Title
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  conventional-pr-title:
+    if: ${{ github.event.pull_request.base.ref == 'main' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate conventional PR title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          pattern='^(feat|fix|docs|chore|refactor|test|perf|build|ci|revert)(\([[:alnum:]_.-]+\))?!?: .+'
+
+          if [[ "$PR_TITLE" =~ $pattern ]]; then
+            echo "PR title is valid: $PR_TITLE"
+            exit 0
+          fi
+
+          echo "PR title must use Conventional Commits because squash merges become release-please input."
+          echo "Allowed prefixes: feat, fix, docs, chore, refactor, test, perf, build, ci, revert"
+          echo "Examples:"
+          echo "  fix: harden push approval auth flow"
+          echo "  feat(auth): add TOTP support"
+          exit 1


### PR DESCRIPTION
## Summary
- add a PR workflow that validates conventional commit style titles for PRs targeting `main`
- fail early on non-releasable squash-merge titles so Release Please always sees `feat:` / `fix:` style commits
- document the reason directly in the workflow output

## Verification
- `uv run pytest -q`
- `uv run ruff check`

## Why
Squash merges use the PR title as the commit title on `main`, and Release Please parses those commit titles to build the changelog and next version.
