### PR TITLE
fix(auth): cache login failures and bound device-approval poll

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ robinhood-mcp
 | `ROBINHOOD_USERNAME` | Yes | Robinhood account email |
 | `ROBINHOOD_PASSWORD` | Yes | Robinhood account password |
 | `ROBINHOOD_TOTP_SECRET` | Recommended | Base32 TOTP secret for 2FA. Strongly recommended for Claude Desktop / headless use — without it, fresh logins fall back to mobile-app push approval, which synchronously blocks the single-threaded MCP server. |
-| `ROBINHOOD_APPROVAL_TIMEOUT` | No | Seconds to wait for push approval (default `30`). Bounds the worst-case server freeze when no TOTP is configured. |
+| `ROBINHOOD_APPROVAL_TIMEOUT` | No | Seconds to wait for push approval (default `60`). Bounds the worst-case server freeze when no TOTP is configured. |
 
 ## Auth failure caching
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,17 @@ robinhood-mcp
 |----------|----------|-------------|
 | `ROBINHOOD_USERNAME` | Yes | Robinhood account email |
 | `ROBINHOOD_PASSWORD` | Yes | Robinhood account password |
-| `ROBINHOOD_TOTP_SECRET` | No | Base32 TOTP secret for 2FA |
+| `ROBINHOOD_TOTP_SECRET` | Recommended | Base32 TOTP secret for 2FA. Strongly recommended for Claude Desktop / headless use — without it, fresh logins fall back to mobile-app push approval, which synchronously blocks the single-threaded MCP server. |
+| `ROBINHOOD_APPROVAL_TIMEOUT` | No | Seconds to wait for push approval (default `30`). Bounds the worst-case server freeze when no TOTP is configured. |
+
+## Auth failure caching
+
+`server.py` `_ensure_logged_in()` caches transient `AuthenticationError`
+failures for ~5 minutes (`_AUTH_FAILURE_COOLDOWN_SECONDS`) so subsequent tool
+calls fail fast instead of re-running the full robin_stocks login flow. After
+the cooldown, one fresh attempt is allowed; restarting Claude Desktop clears
+it immediately. `EnvironmentVariablesError` (missing creds) is still treated
+as permanent — restart is required after fixing config.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -91,10 +91,30 @@ uvx robinhood-mcp
 ```bash
 export ROBINHOOD_USERNAME="your_email"
 export ROBINHOOD_PASSWORD="your_password"
-export ROBINHOOD_TOTP_SECRET="your_2fa_secret"  # Only if you use authenticator app
+export ROBINHOOD_TOTP_SECRET="your_2fa_secret"          # if your account exposes TOTP (see below)
+export ROBINHOOD_APPROVAL_TIMEOUT="60"                  # optional — seconds to wait for push approval
 ```
 
-**Note:** If you use Face ID, Touch ID, or passcode login on Robinhood (no authenticator app), you don't need `ROBINHOOD_TOTP_SECRET`.
+**For Claude Desktop and other headless deployments, you have two paths:**
+
+1. **TOTP, if your account exposes it.** Set `ROBINHOOD_TOTP_SECRET` to the
+   base32 authenticator-app secret (found at *Account → Security → Two-Factor
+   Authentication* in the Robinhood mobile app or at robinhood.com). Login is
+   fast, non-interactive, and survives restarts.
+2. **Push approval, otherwise.** Leave `ROBINHOOD_TOTP_SECRET` unset. The
+   first tool call after a restart triggers a push notification in the
+   Robinhood mobile app — tap "Approve" within `ROBINHOOD_APPROVAL_TIMEOUT`
+   seconds (default 60). After that one approval, the session is cached in
+   `~/.tokens/robinhood.pickle` and reused for days/weeks, with no further
+   interaction until natural expiry.
+
+Newer Robinhood accounts that use passkeys or biometric login as their primary
+2FA may not surface a TOTP option in either the iOS app or web settings —
+push approval works fine for these accounts.
+
+After an authentication failure the server caches the error for ~5 minutes so
+subsequent tool calls fail fast instead of re-blocking the MCP server while
+re-attempting the full login flow. Restart Claude Desktop to retry sooner.
 
 ### Claude Desktop
 
@@ -114,6 +134,9 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
   }
 }
 ```
+
+If your account has TOTP enrollment available, add
+`"ROBINHOOD_TOTP_SECRET": "your_2fa_secret"` to the `env` block above.
 
 ### Claude Code
 
@@ -205,6 +228,14 @@ robinhood-mcp
 - Verify your username and password are correct
 - If you have 2FA with an authenticator app, you need `ROBINHOOD_TOTP_SECRET`
 - Try logging in through the Robinhood app to ensure your account isn't locked
+- **Tool calls hang briefly then fail with "Login returned empty result":** no
+  cached session and no `ROBINHOOD_TOTP_SECRET`, so the server is waiting for
+  you to approve a push notification in the Robinhood mobile app. Tap
+  "Approve" within `ROBINHOOD_APPROVAL_TIMEOUT` seconds (default 60) and call
+  the tool again — the session pickle is now cached and subsequent calls won't
+  prompt. If TOTP is available on your account, adding `ROBINHOOD_TOTP_SECRET`
+  removes the prompt entirely. After a failure the server caches the error for
+  ~5 min; restart Claude Desktop to retry sooner.
 
 **"Non-base32 digit found" error:**
 

--- a/src/robinhood_mcp/auth.py
+++ b/src/robinhood_mcp/auth.py
@@ -31,6 +31,31 @@ from robin_stocks.robinhood.helper import request_get, request_post
 
 logger = logging.getLogger(__name__)
 
+# How long the verification-workflow poll loops will block before failing.
+# 60 seconds is a forgiving window for a user to receive and tap the push
+# notification on their phone, but short enough that the single-threaded MCP
+# server doesn't freeze for minutes if approval never arrives. Override via
+# the ROBINHOOD_APPROVAL_TIMEOUT env var (seconds, float).
+_DEFAULT_APPROVAL_TIMEOUT_SECONDS = 60.0
+_MIN_APPROVAL_TIMEOUT_SECONDS = 5.0
+
+
+def _approval_timeout_seconds() -> float:
+    """Return the configured device-approval poll window, in seconds."""
+    raw = os.getenv("ROBINHOOD_APPROVAL_TIMEOUT")
+    if not raw:
+        return _DEFAULT_APPROVAL_TIMEOUT_SECONDS
+    try:
+        value = float(raw)
+    except ValueError:
+        print(
+            f"[robinhood-mcp] WARNING: ROBINHOOD_APPROVAL_TIMEOUT={raw!r} is "
+            f"not a number; using default {_DEFAULT_APPROVAL_TIMEOUT_SECONDS:.0f}s.",
+            file=sys.stderr,
+        )
+        return _DEFAULT_APPROVAL_TIMEOUT_SECONDS
+    return max(_MIN_APPROVAL_TIMEOUT_SECONDS, value)
+
 
 class AuthenticationError(Exception):
     """Raised when authentication fails."""
@@ -105,6 +130,8 @@ def _patched_validate_sherrif_id(
             f"Verification workflow failed — missing sheriff challenge ID{details}"
         )
 
+    approval_timeout = _approval_timeout_seconds()
+
     # If TOTP mfa_code is available, try direct challenge response first
     if mfa_code:
         challenge_url = f"https://api.robinhood.com/challenge/{challenge_id}/respond/"
@@ -115,7 +142,7 @@ def _patched_validate_sherrif_id(
             # Retry workflow finalization — the workflow may not be immediately
             # ready after TOTP validation (same race the push-approval path handles).
             totp_start = time.time()
-            while time.time() - totp_start < 120:
+            while time.time() - totp_start < approval_timeout:
                 result = _request_workflow_result(inquiries_url)
                 if result == "workflow_status_approved":
                     return
@@ -123,19 +150,21 @@ def _patched_validate_sherrif_id(
                     raise AuthenticationError(f"TOTP validated but workflow not approved: {result}")
                 time.sleep(5)
             raise AuthenticationError(
-                "TOTP validated but workflow finalization timed out after 2 minutes"
+                f"TOTP validated but workflow finalization timed out after {approval_timeout:.0f}s"
             )
 
     # Poll for mobile app approval
     prompts_url = f"https://api.robinhood.com/push/{challenge_id}/get_prompts_status/"
     print(
-        "\n[robinhood-mcp] Verification required — open the Robinhood app and approve the login.\n"
-        "[robinhood-mcp] Waiting up to 2 minutes...",
+        "\n[robinhood-mcp] Verification required — open the Robinhood app and approve the login."
+        f"\n[robinhood-mcp] Waiting up to {approval_timeout:.0f}s "
+        "(set ROBINHOOD_APPROVAL_TIMEOUT to override, or ROBINHOOD_TOTP_SECRET for "
+        "non-interactive 2FA)...",
         file=sys.stderr,
     )
 
     start = time.time()
-    while time.time() - start < 120:
+    while time.time() - start < approval_timeout:
         time.sleep(5)
         status_res = request_get(url=prompts_url)
         elapsed = int(time.time() - start)
@@ -160,7 +189,10 @@ def _patched_validate_sherrif_id(
             raise AuthenticationError(f"Challenge validated but workflow not approved: {result}")
         print(f"[robinhood-mcp] Waiting for approval... ({elapsed}s)", file=sys.stderr)
 
-    raise AuthenticationError("Login timed out after 2 minutes. Restart server and approve in app.")
+    raise AuthenticationError(
+        f"Login timed out after {approval_timeout:.0f}s. Approve in app and call the tool "
+        "again, or set ROBINHOOD_TOTP_SECRET for non-interactive 2FA."
+    )
 
 
 # Apply the monkey-patch before any login calls

--- a/src/robinhood_mcp/server.py
+++ b/src/robinhood_mcp/server.py
@@ -1,5 +1,6 @@
 """FastMCP server for Robinhood portfolio research."""
 
+import math
 import sys
 import threading
 import time
@@ -92,7 +93,10 @@ def _ensure_logged_in() -> None:
         if _auth_failure_message is not None:
             elapsed = time.monotonic() - _auth_failure_ts
             if elapsed < _AUTH_FAILURE_COOLDOWN_SECONDS:
-                remaining = int(_AUTH_FAILURE_COOLDOWN_SECONDS - elapsed)
+                # Ceil so the message never claims "0s" while still inside
+                # the cooldown — int() floors and would lie about sub-second
+                # tails.
+                remaining = math.ceil(_AUTH_FAILURE_COOLDOWN_SECONDS - elapsed)
                 raise RobinhoodError(
                     f"Not logged in: {_auth_failure_message} "
                     f"(cached failure; will retry in {remaining}s)"

--- a/src/robinhood_mcp/server.py
+++ b/src/robinhood_mcp/server.py
@@ -47,6 +47,15 @@ _cached_login_status: bool | None = None
 _cached_login_status_ts = 0.0
 _LOGIN_STATUS_TTL_SECONDS = 5.0
 
+# Cache transient AuthenticationError failures so repeated tool calls don't
+# each re-run the full robin_stocks login flow — that flow can synchronously
+# block the (single-threaded) MCP server for tens of seconds while polling
+# for mobile-app device approval. With the cache, only the first call pays
+# the cost; subsequent calls within the cooldown window fail fast.
+_auth_failure_message: str | None = None
+_auth_failure_ts = 0.0
+_AUTH_FAILURE_COOLDOWN_SECONDS = 300.0
+
 
 def _is_session_valid_cached() -> bool:
     """Return cached login status when fresh, otherwise probe Robinhood once."""
@@ -67,12 +76,29 @@ def _is_session_valid_cached() -> bool:
 
 def _ensure_logged_in() -> None:
     """Ensure we're logged in before API calls, re-attempting if session expired."""
-    global _login_attempted, _login_error, _cached_login_status, _cached_login_status_ts
+    global _login_attempted, _login_error
+    global _cached_login_status, _cached_login_status_ts
+    global _auth_failure_message, _auth_failure_ts
 
     with _login_lock:
         # Only explicit credential/config errors are treated as permanent.
         if _login_error:
             raise RobinhoodError(f"Not logged in: {_login_error}")
+
+        # Recent transient auth failure? Fail fast instead of re-running the
+        # full login flow and freezing the server again. Cooldown clears
+        # automatically so the server can recover after the user fixes things
+        # (or just restarts Claude Desktop).
+        if _auth_failure_message is not None:
+            elapsed = time.monotonic() - _auth_failure_ts
+            if elapsed < _AUTH_FAILURE_COOLDOWN_SECONDS:
+                remaining = int(_AUTH_FAILURE_COOLDOWN_SECONDS - elapsed)
+                raise RobinhoodError(
+                    f"Not logged in: {_auth_failure_message} "
+                    f"(cached failure; will retry in {remaining}s)"
+                )
+            # Cooldown elapsed — allow one fresh attempt.
+            _auth_failure_message = None
 
         session_valid = _is_session_valid_cached() if _login_attempted else False
         if not _login_attempted or not session_valid:
@@ -82,6 +108,7 @@ def _ensure_logged_in() -> None:
                 login()
                 _cached_login_status = True
                 _cached_login_status_ts = time.monotonic()
+                _auth_failure_message = None
                 print("[robinhood-mcp] Logged in to Robinhood", file=sys.stderr)
             except EnvironmentVariablesError as e:
                 _cached_login_status = False
@@ -93,6 +120,8 @@ def _ensure_logged_in() -> None:
                 _cached_login_status = False
                 _cached_login_status_ts = time.monotonic()
                 message = str(e)
+                _auth_failure_message = message
+                _auth_failure_ts = time.monotonic()
                 print(f"[robinhood-mcp] Login failed: {e}", file=sys.stderr)
                 raise RobinhoodError(f"Not logged in: {message}") from e
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -5,7 +5,10 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from robinhood_mcp.auth import (
+    _DEFAULT_APPROVAL_TIMEOUT_SECONDS,
+    _MIN_APPROVAL_TIMEOUT_SECONDS,
     AuthenticationError,
+    _approval_timeout_seconds,
     _clear_stale_pickle,
     _patched_validate_sherrif_id,
     get_totp_code,
@@ -343,6 +346,31 @@ class TestPatchedValidationWorkflow:
         _patched_validate_sherrif_id("device-token", "workflow-id")
 
         assert mock_request_post.call_count == 3
+
+
+class TestApprovalTimeout:
+    """Tests for the ROBINHOOD_APPROVAL_TIMEOUT env var override."""
+
+    @patch.dict("os.environ", {}, clear=True)
+    def test_returns_default_when_unset(self):
+        assert _approval_timeout_seconds() == _DEFAULT_APPROVAL_TIMEOUT_SECONDS
+
+    @patch.dict("os.environ", {"ROBINHOOD_APPROVAL_TIMEOUT": "60"}, clear=True)
+    def test_respects_valid_override(self):
+        assert _approval_timeout_seconds() == 60.0
+
+    @patch.dict("os.environ", {"ROBINHOOD_APPROVAL_TIMEOUT": "0.5"}, clear=True)
+    def test_clamps_below_minimum(self):
+        """Pathologically small values are floored to a safe minimum."""
+        assert _approval_timeout_seconds() == _MIN_APPROVAL_TIMEOUT_SECONDS
+
+    @patch.dict("os.environ", {"ROBINHOOD_APPROVAL_TIMEOUT": "not-a-number"}, clear=True)
+    def test_falls_back_to_default_on_garbage(self, capsys: pytest.CaptureFixture[str]):
+        assert _approval_timeout_seconds() == _DEFAULT_APPROVAL_TIMEOUT_SECONDS
+        captured = capsys.readouterr()
+        # Warning must go to stderr — stdout would corrupt MCP JSON-RPC transport.
+        assert "ROBINHOOD_APPROVAL_TIMEOUT" in captured.err
+        assert captured.out == ""
 
 
 class TestIsLoggedIn:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,106 @@
+"""Tests for the FastMCP server's auth-state caching.
+
+These cover the failure-fast behavior added to `_ensure_logged_in()` so that
+a transient AuthenticationError (e.g. a Robinhood device-approval timeout)
+doesn't cause every subsequent tool call to re-run the full login flow and
+freeze the single-threaded MCP server.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from robinhood_mcp import server
+from robinhood_mcp.auth import AuthenticationError, EnvironmentVariablesError
+from robinhood_mcp.tools import RobinhoodError
+
+
+@pytest.fixture(autouse=True)
+def reset_server_state():
+    """Reset the module-level login-state globals before each test."""
+    server._login_attempted = False
+    server._login_error = None
+    server._cached_login_status = None
+    server._cached_login_status_ts = 0.0
+    server._auth_failure_message = None
+    server._auth_failure_ts = 0.0
+    yield
+    server._login_attempted = False
+    server._login_error = None
+    server._cached_login_status = None
+    server._cached_login_status_ts = 0.0
+    server._auth_failure_message = None
+    server._auth_failure_ts = 0.0
+
+
+class TestEnsureLoggedInCooldown:
+    """Failure-fast cooldown for transient AuthenticationError."""
+
+    @patch("robinhood_mcp.server.login")
+    def test_authentication_error_is_cached_for_subsequent_calls(self, mock_login: MagicMock):
+        """A second call inside the cooldown must NOT re-invoke login()."""
+        mock_login.side_effect = AuthenticationError("device approval timed out")
+
+        with pytest.raises(RobinhoodError):
+            server._ensure_logged_in()
+        with pytest.raises(RobinhoodError) as exc_info:
+            server._ensure_logged_in()
+
+        # login() must only have been called once — the second call should
+        # have short-circuited on the cached failure.
+        assert mock_login.call_count == 1
+        assert "cached failure" in str(exc_info.value)
+        assert "device approval timed out" in str(exc_info.value)
+
+    @patch("robinhood_mcp.server.login")
+    def test_cooldown_expiry_allows_one_fresh_attempt(self, mock_login: MagicMock):
+        """After the cooldown window elapses, login() must be retried."""
+        mock_login.side_effect = AuthenticationError("device approval timed out")
+
+        with pytest.raises(RobinhoodError):
+            server._ensure_logged_in()
+
+        # Pretend the cooldown has fully elapsed.
+        server._auth_failure_ts -= server._AUTH_FAILURE_COOLDOWN_SECONDS + 1
+
+        with pytest.raises(RobinhoodError):
+            server._ensure_logged_in()
+
+        assert mock_login.call_count == 2
+
+    @patch("robinhood_mcp.server.login")
+    def test_successful_login_clears_cached_failure(self, mock_login: MagicMock):
+        """A successful retry must clear the cached-failure state."""
+        mock_login.side_effect = [
+            AuthenticationError("device approval timed out"),
+            {"access_token": "ok"},
+        ]
+
+        with pytest.raises(RobinhoodError):
+            server._ensure_logged_in()
+
+        # Expire the cooldown so the next call retries.
+        server._auth_failure_ts -= server._AUTH_FAILURE_COOLDOWN_SECONDS + 1
+
+        # Successful retry — should not raise.
+        server._ensure_logged_in()
+
+        assert server._auth_failure_message is None
+        assert mock_login.call_count == 2
+
+    @patch("robinhood_mcp.server.login")
+    def test_environment_variables_error_remains_permanent(self, mock_login: MagicMock):
+        """Missing-credentials errors are permanent until restart, not cooldown-cached."""
+        mock_login.side_effect = EnvironmentVariablesError(
+            "ROBINHOOD_USERNAME and ROBINHOOD_PASSWORD environment variables required"
+        )
+
+        with pytest.raises(RobinhoodError):
+            server._ensure_logged_in()
+        with pytest.raises(RobinhoodError) as exc_info:
+            server._ensure_logged_in()
+
+        # Still only one login() call — handled by the existing _login_error path.
+        assert mock_login.call_count == 1
+        # The permanent-error message must not carry the transient-failure suffix.
+        assert "cached failure" not in str(exc_info.value)


### PR DESCRIPTION
## Why

A user report: after restarting Claude Desktop, the robinhood-mcp server appeared "unable to connect" with every tool call hanging ~2 minutes and failing with `RobinhoodError: Not logged in: Login returned empty result`. Diagnosis traced it to the auth path, not the MCP transport — the protocol handshake (`initialize`, `tools/list`) succeeds; only tool *calls* hang.

Root cause: with no cached session pickle and no `ROBINHOOD_TOTP_SECRET`, every login goes through Robinhood's `verification_workflow` device-approval flow. The patched `_validate_sherrif_id` polled synchronously for **120 seconds** waiting for mobile-app approval. The MCP server is single-threaded, so this froze the whole server. The failure was also not cached, so subsequent tool calls repeated the full 2-minute block. With Robinhood increasingly hiding TOTP enrollment for passkey-primary accounts, this is now a realistic state.

## What changed

1. **`server.py`** — `_ensure_logged_in()` now caches transient `AuthenticationError` failures with a 5-minute cooldown (`_AUTH_FAILURE_COOLDOWN_SECONDS`). During the cooldown, subsequent tool calls raise immediately with `(cached failure; will retry in Xs)` instead of re-running the login flow. `EnvironmentVariablesError` (missing creds) stays permanent. A successful login clears the cache.

2. **`auth.py`** — both poll loops in `_patched_validate_sherrif_id` (push-approval and TOTP finalization) now read `ROBINHOOD_APPROVAL_TIMEOUT` via a new `_approval_timeout_seconds()` helper. **Default 60s** (down from 120s), floor 5s, garbage values fall back to the default with a stderr warning (not stdout — protocol safety). Error messages now point users at `ROBINHOOD_TOTP_SECRET` for non-interactive 2FA.

3. **`README.md` + `CLAUDE.md`** — document the new env vars and the failure cache. Reframe TOTP and push-approval as two equally valid paths since Robinhood no longer surfaces TOTP enrollment on every account.

Worst-case server freeze drops from **2 min × every call** to **~60s once, then fast failures for 5 min**.

## Tests

- New `tests/test_server.py` (4 tests): cooldown caches `AuthenticationError`, cooldown expiry allows one retry, success clears the cache, `EnvironmentVariablesError` stays permanent.
- New `TestApprovalTimeout` in `tests/test_auth.py` (4 tests): default value, valid override, sub-minimum clamping, garbage fallback (asserts warning lands on stderr, not stdout).
- 69 tests pass; `ruff check` + `ruff format --check` clean.

## Risk

Behavioral changes are confined to the auth-failure path:

- Shorter approval poll (120s → 60s default) — risk: a slow user misses the window. Mitigation: env override and clearer error message telling them to call the tool again.
- Failure caching — risk: stale "cached failure" after fixing config. Mitigation: 5-min auto-expiry and restarting Claude Desktop clears immediately.
- Existing `TestPatchedValidationWorkflow` tests still pass; the mocked `time.time` progression has plenty of headroom under the new shorter loop.

Read-only tool surface unchanged; no new tools or trading paths.