### PR TITLE
docs(readme): embed Robinhood MCP demo video

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ A read-only MCP server for Robinhood portfolio research. Wraps [robin_stocks](ht
 
 > **⚠️ Unofficial API** - Uses robin_stocks unofficial API. May break without notice. Use at your own risk.
 
+## Demo
+
+<video src="https://github.com/user-attachments/assets/454263bc-8da7-4644-89df-c48e5401dbac" controls muted playsinline></video>
+
+[Watch the simulated product demo](https://github.com/user-attachments/assets/454263bc-8da7-4644-89df-c48e5401dbac)
+
+This demo uses simulated account data and a generic assistant interface. It shows read-only research workflows only; it does not show real credentials, real holdings, professional advice, or trade execution.
+
 ## What Can You Do With This?
 
 Once connected, you can have natural conversations with Claude about your portfolio:


### PR DESCRIPTION
Summary
- embed the simulated Robinhood MCP demo from a GitHub user-attachments URL
- keep Remotion source, generated media, Suno archives, and dependency trees out of repo history
- preserve the read-only/simulated-data disclaimer in the README

Tests
- uv run --extra dev ruff check .
- uv run --extra dev ruff format --check .
- uv run --extra dev pytest -q
- verified video URL with ranged GET: 206 Partial Content, Content-Type: video/mp4, 4,367,118 bytes
- verified PR diff is README.md only

Breaking Changes
None.