### PR TITLE
docs(readme): improve demo video preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ A read-only MCP server for Robinhood portfolio research. Wraps [robin_stocks](ht
 
 ## Demo
 
-[Watch the simulated product demo](https://github.com/user-attachments/assets/454263bc-8da7-4644-89df-c48e5401dbac)
+<video src="https://github.com/user-attachments/assets/c690d641-8f8d-4bbd-8462-3d2c2e25b38e" controls muted playsinline></video>
+
+<p><a href="https://github.com/verygoodplugins/robinhood-mcp/pull/20#issuecomment-4579826755">Watch the simulated product demo</a></p>
 
 This demo uses simulated account data and a generic assistant interface. It shows read-only research workflows only; it does not show real credentials, real holdings, professional advice, or trade execution.
 


### PR DESCRIPTION
Summary
- replace the README demo with a newly uploaded MP4 whose first frame is a nonblank title slate
- render the demo as one video element and move the fallback link to the PR asset comment so GitHub does not auto-render a duplicate video
- keep generated media/source out of repo history; the PR changes README.md only

Tests
- uv run --extra dev ruff check .
- uv run --extra dev ruff format --check .
- uv run --extra dev pytest -q
- verified video URL with ranged GET: 206 Partial Content, Content-Type: video/mp4, 3,722,212 bytes
- verified rendered GitHub README branch view has videoCount=1, one text fallback link, and the simulated-data disclaimer

Breaking Changes
None.