### PR TITLE
feat(accounts): support Robinhood account selection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ This file provides guidance to Claude Code when working with this repository.
 src/robinhood_mcp/
 ├── __init__.py      # Package version
 ├── auth.py          # Authentication with TOTP support
-├── tools.py         # 14 read-only tool implementations
+├── tools.py         # 15 read-only tool implementations
 └── server.py        # FastMCP server with tool registration
 ```
 

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ claude mcp add robinhood -- uvx robinhood-mcp
 
 | Tool                              | Description                                          |
 | --------------------------------- | ---------------------------------------------------- |
+| `robinhood_get_accounts`          | Account numbers for available Robinhood accounts     |
 | `robinhood_get_portfolio`         | Portfolio value, equity, buying power, day change    |
 | `robinhood_get_positions`         | All holdings with cost basis, current value, P&L     |
 | `robinhood_get_position`          | One holding by ticker with quantity, value, and P&L  |
@@ -171,6 +172,21 @@ claude mcp add robinhood -- uvx robinhood-mcp
 | `robinhood_get_order_history`     | Order history (buys/sells) with per-fill detail      |
 | `robinhood_search_symbols`        | Search stocks by name or ticker                      |
 
+### Account Selection
+
+If your Robinhood login has multiple accounts, call `robinhood_get_accounts`
+first and pass the returned `account_number` to account-scoped tools. Omit
+`account_number` to use Robinhood's default account.
+
+Tools with optional `account_number` support:
+
+- `robinhood_get_portfolio`
+- `robinhood_get_positions`
+- `robinhood_get_position`
+- `robinhood_get_dividends`
+- `robinhood_get_options_positions`
+- `robinhood_get_order_history`
+
 ## Example Conversations
 
 **Simple queries:**
@@ -178,6 +194,7 @@ claude mcp add robinhood -- uvx robinhood-mcp
 - "What's my portfolio worth right now?"
 - "Show me my top 5 holdings by value"
 - "Do I already own HIMS, and what's my current position?"
+- "List my Robinhood accounts, then show positions for my IRA account."
 - "Get me a quote for AAPL"
 
 For single-symbol portfolio questions, prefer `robinhood_get_position` over

--- a/server.json
+++ b/server.json
@@ -21,16 +21,20 @@
   ],
   "tools": [
     {
+      "name": "robinhood_get_accounts",
+      "description": "List account numbers for available Robinhood accounts"
+    },
+    {
       "name": "robinhood_get_portfolio",
-      "description": "Get portfolio value and performance"
+      "description": "Get portfolio value and performance, optionally by account"
     },
     {
       "name": "robinhood_get_positions",
-      "description": "Get current stock holdings"
+      "description": "Get current stock holdings, optionally by account"
     },
     {
       "name": "robinhood_get_position",
-      "description": "Get one stock holding by ticker"
+      "description": "Get one stock holding by ticker, optionally by account"
     },
     {
       "name": "robinhood_get_watchlist",
@@ -62,15 +66,15 @@
     },
     {
       "name": "robinhood_get_dividends",
-      "description": "Get dividend payment history"
+      "description": "Get dividend payment history, optionally by account"
     },
     {
       "name": "robinhood_get_options_positions",
-      "description": "Get options positions"
+      "description": "Get options positions, optionally by account"
     },
     {
       "name": "robinhood_get_order_history",
-      "description": "Get stock order history (buys and sells)"
+      "description": "Get stock order history (buys and sells), optionally by account"
     },
     {
       "name": "robinhood_search_symbols",

--- a/src/robinhood_mcp/server.py
+++ b/src/robinhood_mcp/server.py
@@ -12,6 +12,7 @@ from fastmcp import FastMCP
 from .auth import AuthenticationError, EnvironmentVariablesError, is_logged_in, login
 from .tools import (
     RobinhoodError,
+    get_accounts,
     get_dividends,
     get_earnings,
     get_fundamentals,
@@ -131,39 +132,57 @@ def _ensure_logged_in() -> None:
 
 
 @mcp.tool()
-def robinhood_get_portfolio() -> dict:
+def robinhood_get_accounts() -> list:
+    """List available Robinhood accounts for account_number selection.
+
+    Use this to find account numbers for account-scoped tools when a Robinhood
+    login has multiple accounts, such as a taxable account and IRA.
+    """
+    _ensure_logged_in()
+    return get_accounts()
+
+
+@mcp.tool()
+def robinhood_get_portfolio(account_number: str | None = None) -> dict:
     """Get current portfolio value and performance metrics.
+
+    Args:
+        account_number: Optional Robinhood account number. Omit for the default account.
 
     Returns portfolio profile with equity, extended hours equity,
     withdrawable amount, and other account details.
     """
     _ensure_logged_in()
-    return get_portfolio()
+    return get_portfolio(account_number)
 
 
 @mcp.tool()
-def robinhood_get_positions() -> dict:
+def robinhood_get_positions(account_number: str | None = None) -> dict:
     """Get all current stock positions with details.
+
+    Args:
+        account_number: Optional Robinhood account number. Omit for the default account.
 
     Returns a dict mapping stock symbols to position details including
     price, quantity, average buy price, equity, and percent change.
     """
     _ensure_logged_in()
-    return get_positions()
+    return get_positions(account_number)
 
 
 @mcp.tool()
-def robinhood_get_position(symbol: str) -> dict:
+def robinhood_get_position(symbol: str, account_number: str | None = None) -> dict:
     """Get one current stock position with a faster single-symbol lookup.
 
     Args:
         symbol: Stock ticker symbol (e.g., "HIMS", "AAPL")
+        account_number: Optional Robinhood account number. Omit for the default account.
 
     Returns a dict with held=False if absent, otherwise the position details
     for that symbol including quantity, price, average buy price, and P&L.
     """
     _ensure_logged_in()
-    return get_position(symbol)
+    return get_position(symbol, account_number)
 
 
 @mcp.tool()
@@ -269,25 +288,31 @@ def robinhood_get_ratings(symbol: str) -> dict:
 
 
 @mcp.tool()
-def robinhood_get_dividends() -> list:
+def robinhood_get_dividends(account_number: str | None = None) -> list:
     """Get all dividend payments received.
+
+    Args:
+        account_number: Optional Robinhood account number. Omit for all returned dividends.
 
     Returns list of dividend payments with amount, payable date,
     record date, and instrument details.
     """
     _ensure_logged_in()
-    return get_dividends()
+    return get_dividends(account_number)
 
 
 @mcp.tool()
-def robinhood_get_options_positions() -> list:
+def robinhood_get_options_positions(account_number: str | None = None) -> list:
     """Get all current options positions (read-only).
+
+    Args:
+        account_number: Optional Robinhood account number. Omit for the default account.
 
     Returns list of options positions with chain symbol, type,
     strike price, expiration, and quantity.
     """
     _ensure_logged_in()
-    return get_options_positions()
+    return get_options_positions(account_number)
 
 
 @mcp.tool()
@@ -296,6 +321,7 @@ def robinhood_get_order_history(
     state: Literal["executed", "all"] = "executed",
     limit: int = 50,
     start_date: str | None = None,
+    account_number: str | None = None,
 ) -> list:
     """Get historical stock order history (executed buys and sells).
 
@@ -309,13 +335,14 @@ def robinhood_get_order_history(
             partial fills; "all" also returns cancelled/queued/rejected orders.
         limit: Maximum number of orders to return, most recent first.
         start_date: Optional "YYYY-MM-DD" lower bound, applied server-side.
+        account_number: Optional Robinhood account number. Omit for the default account.
 
     Returns a list of order rows (newest first) with symbol, side, state,
     quantity, filled quantity, average price, type, timestamps, and per-fill
     executions.
     """
     _ensure_logged_in()
-    return get_order_history(symbol, state, limit, start_date)
+    return get_order_history(symbol, state, limit, start_date, account_number)
 
 
 @mcp.tool()

--- a/src/robinhood_mcp/tools.py
+++ b/src/robinhood_mcp/tools.py
@@ -179,6 +179,17 @@ def _slim_positions(positions: dict[str, dict[str, Any]]) -> dict[str, dict[str,
     }
 
 
+def _is_zero_quantity_position(position: dict[str, Any]) -> bool:
+    """Return whether a raw position row has a parseable zero quantity."""
+    quantity = position.get("quantity")
+    if quantity in (None, ""):
+        return False
+    try:
+        return float(quantity) == 0.0
+    except (TypeError, ValueError):
+        return False
+
+
 def _position_data_from_open_position(symbol: str, position: dict[str, Any]) -> dict[str, Any]:
     """Build slim position fields from one raw open-position row."""
     quote = get_quote(symbol)
@@ -221,6 +232,8 @@ def _build_account_holdings(account_number: str) -> dict[str, dict[str, Any]]:
     holdings: dict[str, dict[str, Any]] = {}
     for position in positions:
         if not isinstance(position, dict):
+            continue
+        if _is_zero_quantity_position(position):
             continue
         symbol = _resolve_symbol_by_url(position.get("instrument") or "")
         if symbol is None:
@@ -327,7 +340,9 @@ def get_position(symbol: str, account_number: str | None = None) -> dict[str, An
         (
             item
             for item in positions
-            if isinstance(item, dict) and item.get("instrument") == instrument_url
+            if isinstance(item, dict)
+            and item.get("instrument") == instrument_url
+            and not _is_zero_quantity_position(item)
         ),
         None,
     )

--- a/src/robinhood_mcp/tools.py
+++ b/src/robinhood_mcp/tools.py
@@ -1,5 +1,6 @@
 """Read-only Robinhood tools wrapping robin_stocks library."""
 
+import re
 import threading
 import time
 from collections.abc import Callable
@@ -16,9 +17,10 @@ class RobinhoodError(Exception):
 
 
 _POSITIONS_CACHE_TTL_SECONDS = 30.0
+_ACCOUNT_NUMBER_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 _positions_cache_lock = threading.Lock()
-_positions_cache: dict[str, dict[str, Any]] | None = None
-_positions_cache_ts = 0.0
+_positions_cache: dict[str | None, dict[str, dict[str, Any]]] = {}
+_positions_cache_ts: dict[str | None, float] = {}
 
 
 def _safe_call(func: Callable[..., Any], *args, **kwargs) -> Any:
@@ -56,45 +58,105 @@ def _normalize_symbol(symbol: str) -> str:
     return symbol
 
 
+def _normalize_account_number(account_number: str | None) -> str | None:
+    """Normalize and validate an optional Robinhood account number."""
+    if account_number is None:
+        return None
+    if not isinstance(account_number, str):
+        raise RobinhoodError("account_number must be a string")
+
+    account_number = account_number.strip()
+    if not account_number:
+        raise RobinhoodError("account_number must be a non-empty string")
+    if not _ACCOUNT_NUMBER_RE.fullmatch(account_number):
+        raise RobinhoodError(
+            "account_number may contain only letters, numbers, underscores, and hyphens"
+        )
+    return account_number
+
+
+def _account_kwargs(account_number: str | None) -> dict[str, str]:
+    """Return robin_stocks kwargs, preserving no-arg calls for the default account."""
+    return {} if account_number is None else {"account_number": account_number}
+
+
 def _clear_positions_cache() -> None:
     """Reset the cached holdings snapshot."""
     global _positions_cache, _positions_cache_ts
 
     with _positions_cache_lock:
-        _positions_cache = None
-        _positions_cache_ts = 0.0
+        _positions_cache = {}
+        _positions_cache_ts = {}
 
 
-def _get_positions_cached(now: float) -> dict[str, dict[str, Any]] | None:
+def _get_positions_cached(
+    now: float, account_number: str | None = None
+) -> dict[str, dict[str, Any]] | None:
     """Return cached holdings when still fresh."""
     global _positions_cache, _positions_cache_ts
 
     with _positions_cache_lock:
-        if _positions_cache is None:
+        if account_number not in _positions_cache:
             return None
-        if (now - _positions_cache_ts) >= _POSITIONS_CACHE_TTL_SECONDS:
-            _positions_cache = None
-            _positions_cache_ts = 0.0
+        if (now - _positions_cache_ts.get(account_number, 0.0)) >= _POSITIONS_CACHE_TTL_SECONDS:
+            _positions_cache.pop(account_number, None)
+            _positions_cache_ts.pop(account_number, None)
             return None
-        return deepcopy(_positions_cache)
+        return deepcopy(_positions_cache[account_number])
 
 
-def _set_positions_cache(positions: dict[str, dict[str, Any]], now: float) -> None:
+def _set_positions_cache(
+    positions: dict[str, dict[str, Any]], now: float, account_number: str | None = None
+) -> None:
     """Store a fresh holdings snapshot for subsequent reads."""
     global _positions_cache, _positions_cache_ts
 
     with _positions_cache_lock:
-        _positions_cache = deepcopy(positions)
-        _positions_cache_ts = now
+        _positions_cache[account_number] = deepcopy(positions)
+        _positions_cache_ts[account_number] = now
 
 
-def get_portfolio() -> dict[str, Any]:
+_ACCOUNT_FIELDS = (
+    "account_number",
+    "type",
+    "state",
+    "buying_power",
+    "cash",
+    "portfolio_cash",
+    "cash_available_for_withdrawal",
+    "deactivated",
+    "locked",
+)
+
+
+def get_accounts() -> list[dict[str, Any]]:
+    """Get available Robinhood accounts with fields needed for selection.
+
+    Returns:
+        List of account profiles including account_number, type, state, and
+        high-level cash/buying-power fields.
+    """
+    result = _safe_call(rh.profiles.load_account_profile, dataType="results")
+    if not isinstance(result, list):
+        raise RobinhoodError(f"Unexpected account profile response type: {type(result).__name__}")
+    return [
+        {field: account.get(field) for field in _ACCOUNT_FIELDS}
+        for account in result
+        if isinstance(account, dict)
+    ]
+
+
+def get_portfolio(account_number: str | None = None) -> dict[str, Any]:
     """Get current portfolio value and performance metrics.
+
+    Args:
+        account_number: Optional Robinhood account number. Omit for the default account.
 
     Returns:
         Portfolio profile with equity, extended hours equity, market value, etc.
     """
-    return _safe_call(rh.profiles.load_portfolio_profile)
+    account_number = _normalize_account_number(account_number)
+    return _safe_call(rh.profiles.load_portfolio_profile, **_account_kwargs(account_number))
 
 
 _POSITION_FIELDS = (
@@ -117,8 +179,64 @@ def _slim_positions(positions: dict[str, dict[str, Any]]) -> dict[str, dict[str,
     }
 
 
-def get_positions() -> dict[str, dict[str, Any]]:
+def _position_data_from_open_position(symbol: str, position: dict[str, Any]) -> dict[str, Any]:
+    """Build slim position fields from one raw open-position row."""
+    quote = get_quote(symbol)
+    price = quote.get("last_trade_price") or quote.get("mark_price")
+    quantity = position.get("quantity")
+    average_buy_price = position.get("average_buy_price")
+    if price in (None, "") or quantity in (None, "") or average_buy_price in (None, ""):
+        raise RobinhoodError(f"Incomplete position data for symbol: {symbol}")
+
+    try:
+        quantity_f = float(quantity)
+        price_f = float(price)
+        average_buy_price_f = float(average_buy_price)
+    except (TypeError, ValueError) as e:
+        raise RobinhoodError(f"Invalid numeric position data for symbol: {symbol}") from e
+
+    equity = quantity_f * price_f
+    equity_change = equity - (quantity_f * average_buy_price_f)
+    percent_change = (
+        0.0
+        if average_buy_price_f == 0.0
+        else ((price_f - average_buy_price_f) * 100 / average_buy_price_f)
+    )
+    return {
+        "price": f"{price_f:.2f}",
+        "quantity": quantity,
+        "average_buy_price": average_buy_price,
+        "equity": f"{equity:.2f}",
+        "percent_change": f"{percent_change:.2f}",
+        "equity_change": f"{equity_change:.2f}",
+    }
+
+
+def _build_account_holdings(account_number: str) -> dict[str, dict[str, Any]]:
+    """Build current stock holdings for a specific account number."""
+    positions = _safe_call(rh.account.get_open_stock_positions, **_account_kwargs(account_number))
+    if not isinstance(positions, list):
+        raise RobinhoodError("Unexpected positions response type")
+
+    holdings: dict[str, dict[str, Any]] = {}
+    for position in positions:
+        if not isinstance(position, dict):
+            continue
+        symbol = _resolve_symbol_by_url(position.get("instrument") or "")
+        if symbol is None:
+            continue
+        try:
+            holdings[symbol] = _position_data_from_open_position(symbol, position)
+        except RobinhoodError:
+            continue
+    return holdings
+
+
+def get_positions(account_number: str | None = None) -> dict[str, dict[str, Any]]:
     """Get all current stock positions with details.
+
+    Args:
+        account_number: Optional Robinhood account number. Omit for the default account.
 
     Returns:
         Dict mapping symbol to position details including:
@@ -131,26 +249,30 @@ def get_positions() -> dict[str, dict[str, Any]]:
     """
     global _positions_cache, _positions_cache_ts
 
+    account_number = _normalize_account_number(account_number)
     now = time.monotonic()
-    cached = _get_positions_cached(now)
+    cached = _get_positions_cached(now, account_number)
     if cached is not None:
         return _slim_positions(cached)
 
     with _positions_cache_lock:
         now = time.monotonic()
         if (
-            _positions_cache is not None
-            and (now - _positions_cache_ts) < _POSITIONS_CACHE_TTL_SECONDS
+            account_number in _positions_cache
+            and (now - _positions_cache_ts.get(account_number, 0.0)) < _POSITIONS_CACHE_TTL_SECONDS
         ):
-            return _slim_positions(deepcopy(_positions_cache))
+            return _slim_positions(deepcopy(_positions_cache[account_number]))
 
-        result = _safe_call(rh.account.build_holdings)
+        if account_number is None:
+            result = _safe_call(rh.account.build_holdings)
+        else:
+            result = _build_account_holdings(account_number)
         if not isinstance(result, dict):
             raise RobinhoodError(
                 f"Unexpected build_holdings response type: {type(result).__name__}"
             )
-        _positions_cache = deepcopy(result)
-        _positions_cache_ts = time.monotonic()
+        _positions_cache[account_number] = deepcopy(result)
+        _positions_cache_ts[account_number] = time.monotonic()
         return _slim_positions(result)
 
 
@@ -174,15 +296,20 @@ def _validate_symbol_instrument(symbol: str) -> str:
     return instruments[0]["url"]
 
 
-def get_position(symbol: str) -> dict[str, Any]:
+def get_position(symbol: str, account_number: str | None = None) -> dict[str, Any]:
     """Get a single position by symbol without rebuilding all holdings.
+
+    Args:
+        symbol: Stock ticker symbol.
+        account_number: Optional Robinhood account number. Omit for the default account.
 
     Returns:
         Dict with held=False if absent, otherwise position details including
         price, quantity, average_buy_price, equity, percent_change, and equity_change.
     """
     symbol = _normalize_symbol(symbol)
-    cached_positions = _get_positions_cached(time.monotonic())
+    account_number = _normalize_account_number(account_number)
+    cached_positions = _get_positions_cached(time.monotonic(), account_number)
     if cached_positions is not None:
         cached_position = cached_positions.get(symbol)
         if isinstance(cached_position, dict):
@@ -192,7 +319,7 @@ def get_position(symbol: str) -> dict[str, Any]:
 
     instrument_url = _validate_symbol_instrument(symbol)
 
-    positions = _safe_call(rh.account.get_open_stock_positions)
+    positions = _safe_call(rh.account.get_open_stock_positions, **_account_kwargs(account_number))
     if not isinstance(positions, list):
         raise RobinhoodError("Unexpected positions response type")
 
@@ -207,38 +334,7 @@ def get_position(symbol: str) -> dict[str, Any]:
     if not match:
         return {"symbol": symbol, "held": False}
 
-    quote = get_quote(symbol)
-    price = quote.get("last_trade_price") or quote.get("mark_price")
-    quantity = match.get("quantity")
-    average_buy_price = match.get("average_buy_price")
-    if price in (None, "") or quantity in (None, "") or average_buy_price in (None, ""):
-        raise RobinhoodError(f"Incomplete position data for symbol: {symbol}")
-
-    try:
-        quantity_f = float(quantity)
-        price_f = float(price)
-        average_buy_price_f = float(average_buy_price)
-    except (TypeError, ValueError) as e:
-        raise RobinhoodError(f"Invalid numeric position data for symbol: {symbol}") from e
-
-    equity = quantity_f * price_f
-    equity_change = equity - (quantity_f * average_buy_price_f)
-    percent_change = (
-        0.0
-        if average_buy_price_f == 0.0
-        else ((price_f - average_buy_price_f) * 100 / average_buy_price_f)
-    )
-    return _position_payload(
-        symbol,
-        {
-            "price": f"{price_f:.2f}",
-            "quantity": quantity,
-            "average_buy_price": average_buy_price,
-            "equity": f"{equity:.2f}",
-            "percent_change": f"{percent_change:.2f}",
-            "equity_change": f"{equity_change:.2f}",
-        },
-    )
+    return _position_payload(symbol, _position_data_from_open_position(symbol, match))
 
 
 def get_watchlist(name: str = "Default") -> list[dict[str, Any]]:
@@ -362,23 +458,50 @@ def get_ratings(symbol: str) -> dict[str, Any]:
     raise RobinhoodError(f"No ratings found for symbol: {symbol}")
 
 
-def get_dividends() -> list[dict[str, Any]]:
+def _matches_account(payload: dict[str, Any], account_number: str) -> bool:
+    """Return whether a Robinhood payload row belongs to an account."""
+    if payload.get("account_number") == account_number:
+        return True
+
+    account = payload.get("account")
+    if not isinstance(account, str):
+        return False
+    return account.rstrip("/").split("/")[-1] == account_number
+
+
+def get_dividends(account_number: str | None = None) -> list[dict[str, Any]]:
     """Get all dividend payments received.
+
+    Args:
+        account_number: Optional Robinhood account number. Omit for all returned dividends.
 
     Returns:
         List of dividend payments with amount, payable_date, record_date, etc.
     """
+    account_number = _normalize_account_number(account_number)
     result = _safe_call(rh.account.get_dividends)
-    return result if isinstance(result, list) else []
+    if not isinstance(result, list):
+        return []
+    if account_number is None:
+        return result
+    return [
+        dividend
+        for dividend in result
+        if isinstance(dividend, dict) and _matches_account(dividend, account_number)
+    ]
 
 
-def get_options_positions() -> list[dict[str, Any]]:
+def get_options_positions(account_number: str | None = None) -> list[dict[str, Any]]:
     """Get all current options positions.
+
+    Args:
+        account_number: Optional Robinhood account number. Omit for the default account.
 
     Returns:
         List of options positions with chain_symbol, type, quantity, etc.
     """
-    result = _safe_call(rh.options.get_open_option_positions)
+    account_number = _normalize_account_number(account_number)
+    result = _safe_call(rh.options.get_open_option_positions, **_account_kwargs(account_number))
     return result if isinstance(result, list) else []
 
 
@@ -493,6 +616,7 @@ def get_order_history(
     state: Literal["executed", "all"] = "executed",
     limit: int = 50,
     start_date: str | None = None,
+    account_number: str | None = None,
 ) -> list[dict[str, Any]]:
     """Get historical stock order history (executed buys and sells).
 
@@ -507,6 +631,7 @@ def get_order_history(
             queued, and rejected ones.
         limit: Maximum number of orders to return, most recent first.
         start_date: Optional "YYYY-MM-DD" lower bound, applied server-side.
+        account_number: Optional Robinhood account number. Omit for the default account.
 
     Returns:
         List of order rows, newest first, each with symbol, side, state,
@@ -519,13 +644,18 @@ def get_order_history(
     if not isinstance(limit, int) or limit <= 0:
         raise RobinhoodError("limit must be a positive integer")
 
+    account_number = _normalize_account_number(account_number)
     instrument_url: str | None = None
     resolved_symbol: str | None = None
     if symbol is not None:
         resolved_symbol = _normalize_symbol(symbol)
         instrument_url = _validate_symbol_instrument(resolved_symbol)
 
-    orders = _safe_call(rh.orders.get_all_stock_orders, start_date=start_date)
+    orders = _safe_call(
+        rh.orders.get_all_stock_orders,
+        start_date=start_date,
+        **_account_kwargs(account_number),
+    )
     if not isinstance(orders, list):
         raise RobinhoodError(f"Unexpected order history response type: {type(orders).__name__}")
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -33,6 +33,11 @@ def reset_server_state():
     server._auth_failure_ts = 0.0
 
 
+def _call_tool(tool, *args, **kwargs):
+    """Call either a plain FastMCP function or a FunctionTool wrapper."""
+    return getattr(tool, "fn", tool)(*args, **kwargs)
+
+
 class TestEnsureLoggedInCooldown:
     """Failure-fast cooldown for transient AuthenticationError."""
 
@@ -104,3 +109,40 @@ class TestEnsureLoggedInCooldown:
         assert mock_login.call_count == 1
         # The permanent-error message must not carry the transient-failure suffix.
         assert "cached failure" not in str(exc_info.value)
+
+
+class TestAccountNumberForwarding:
+    """Server wrappers forward optional account selection to tool functions."""
+
+    @patch("robinhood_mcp.server.get_portfolio")
+    @patch("robinhood_mcp.server._ensure_logged_in")
+    def test_portfolio_forwards_account_number(
+        self, mock_ensure: MagicMock, mock_get_portfolio: MagicMock
+    ):
+        mock_get_portfolio.return_value = {"equity": "2500.00"}
+
+        result = _call_tool(server.robinhood_get_portfolio, account_number="IRA123")
+
+        assert result == {"equity": "2500.00"}
+        mock_ensure.assert_called_once_with()
+        mock_get_portfolio.assert_called_once_with("IRA123")
+
+    @patch("robinhood_mcp.server.get_order_history")
+    @patch("robinhood_mcp.server._ensure_logged_in")
+    def test_order_history_forwards_account_number(
+        self, mock_ensure: MagicMock, mock_get_order_history: MagicMock
+    ):
+        mock_get_order_history.return_value = []
+
+        result = _call_tool(
+            server.robinhood_get_order_history,
+            symbol="HIMS",
+            state="all",
+            limit=10,
+            start_date="2026-01-01",
+            account_number="IRA123",
+        )
+
+        assert result == []
+        mock_ensure.assert_called_once_with()
+        mock_get_order_history.assert_called_once_with("HIMS", "all", 10, "2026-01-01", "IRA123")

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -393,6 +393,28 @@ class TestGetPositions:
         mock_open_positions.assert_called_once_with(account_number="IRA123")
         mock_build_holdings.assert_not_called()
 
+    @patch("robinhood_mcp.tools.get_quote")
+    @patch("robinhood_mcp.tools.rh.stocks.get_symbol_by_url")
+    @patch("robinhood_mcp.tools.rh.account.get_open_stock_positions")
+    def test_account_number_skips_zero_quantity_positions(
+        self,
+        mock_open_positions: MagicMock,
+        mock_symbol: MagicMock,
+        mock_get_quote: MagicMock,
+    ):
+        """Should skip fully closed rows returned by open-stock-position API."""
+        mock_open_positions.return_value = [
+            {
+                "instrument": "https://instrument/hims/",
+                "quantity": "0.00000000",
+                "average_buy_price": "20.00",
+            }
+        ]
+
+        assert get_positions(account_number="IRA123") == {}
+        mock_symbol.assert_not_called()
+        mock_get_quote.assert_not_called()
+
 
 class TestGetPosition:
     """Tests for get_position function."""
@@ -506,6 +528,30 @@ class TestGetPosition:
         assert result["held"] is True
         mock_open_positions.assert_called_once_with(account_number="IRA123")
         mock_build_holdings.assert_not_called()
+
+    @patch("robinhood_mcp.tools.get_quote")
+    @patch("robinhood_mcp.tools.rh.account.get_open_stock_positions")
+    @patch("robinhood_mcp.tools.rh.stocks.get_instruments_by_symbols")
+    def test_zero_quantity_account_position_returns_not_held(
+        self,
+        mock_get_instruments: MagicMock,
+        mock_open_positions: MagicMock,
+        mock_get_quote: MagicMock,
+    ):
+        """Should report held=False for fully closed account-specific rows."""
+        mock_get_instruments.return_value = [{"url": "https://instrument/hims/"}]
+        mock_open_positions.return_value = [
+            {
+                "instrument": "https://instrument/hims/",
+                "quantity": "0.00000000",
+                "average_buy_price": "20.00",
+            }
+        ]
+
+        result = get_position("HIMS", account_number="IRA123")
+
+        assert result == {"symbol": "HIMS", "held": False}
+        mock_get_quote.assert_not_called()
 
     @patch("robinhood_mcp.tools.get_quote")
     @patch("robinhood_mcp.tools.rh.account.get_open_stock_positions")

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -74,6 +74,76 @@ def _make_order(
     }
 
 
+class TestGetAccounts:
+    """Tests for get_accounts function."""
+
+    @patch("robinhood_mcp.tools.rh.profiles.load_account_profile")
+    def test_returns_slimmed_account_profiles(self, mock_profile: MagicMock):
+        """Should return account profiles with fields useful for selection."""
+        mock_profile.return_value = [
+            {
+                "account_number": "IRA123",
+                "type": "traditional_ira",
+                "state": "active",
+                "buying_power": "100.00",
+                "cash": "50.00",
+                "portfolio_cash": "25.00",
+                "cash_available_for_withdrawal": "10.00",
+                "deactivated": False,
+                "locked": False,
+                "url": "https://api.robinhood.com/accounts/IRA123/",
+                "user": "https://api.robinhood.com/user/",
+            },
+            {
+                "account_number": "TAXABLE456",
+                "type": "margin",
+                "state": "active",
+                "buying_power": "200.00",
+                "cash": "75.00",
+                "portfolio_cash": "35.00",
+                "cash_available_for_withdrawal": "20.00",
+                "deactivated": False,
+                "locked": False,
+            },
+        ]
+
+        result = tools_module.get_accounts()
+
+        assert result == [
+            {
+                "account_number": "IRA123",
+                "type": "traditional_ira",
+                "state": "active",
+                "buying_power": "100.00",
+                "cash": "50.00",
+                "portfolio_cash": "25.00",
+                "cash_available_for_withdrawal": "10.00",
+                "deactivated": False,
+                "locked": False,
+            },
+            {
+                "account_number": "TAXABLE456",
+                "type": "margin",
+                "state": "active",
+                "buying_power": "200.00",
+                "cash": "75.00",
+                "portfolio_cash": "35.00",
+                "cash_available_for_withdrawal": "20.00",
+                "deactivated": False,
+                "locked": False,
+            },
+        ]
+        mock_profile.assert_called_once_with(dataType="results")
+
+    @patch("robinhood_mcp.tools.rh.profiles.load_account_profile")
+    def test_raises_on_non_list_response(self, mock_profile: MagicMock):
+        """Should raise RobinhoodError when account list has an unexpected shape."""
+        mock_profile.return_value = {"unexpected": "shape"}
+
+        with pytest.raises(RobinhoodError):
+            tools_module.get_accounts()
+
+
 class TestGetPortfolio:
     """Tests for get_portfolio function."""
 
@@ -90,6 +160,24 @@ class TestGetPortfolio:
 
         assert result == expected
         mock_profile.assert_called_once()
+
+    @patch("robinhood_mcp.tools.rh.profiles.load_portfolio_profile")
+    def test_forwards_account_number(self, mock_profile: MagicMock):
+        """Should request a specific account's portfolio when account_number is given."""
+        mock_profile.return_value = {"equity": "2500.00"}
+
+        result = get_portfolio(account_number=" IRA123 ")
+
+        assert result == {"equity": "2500.00"}
+        mock_profile.assert_called_once_with(account_number="IRA123")
+
+    @patch("robinhood_mcp.tools.rh.profiles.load_portfolio_profile")
+    def test_rejects_invalid_account_number(self, mock_profile: MagicMock):
+        """Should reject unsafe account numbers before they reach robin_stocks."""
+        with pytest.raises(RobinhoodError):
+            get_portfolio(account_number="IRA123&account_numbers=OTHER")
+
+        mock_profile.assert_not_called()
 
     @patch("robinhood_mcp.tools.rh.profiles.load_portfolio_profile")
     def test_raises_on_none_result(self, mock_profile: MagicMock):
@@ -268,6 +356,43 @@ class TestGetPositions:
         assert get_positions() == {}
         assert mock_holdings.call_count == 1
 
+    @patch("robinhood_mcp.tools.get_quote")
+    @patch("robinhood_mcp.tools.rh.stocks.get_symbol_by_url")
+    @patch("robinhood_mcp.tools.rh.account.get_open_stock_positions")
+    @patch("robinhood_mcp.tools.rh.account.build_holdings")
+    def test_account_number_uses_account_specific_positions(
+        self,
+        mock_build_holdings: MagicMock,
+        mock_open_positions: MagicMock,
+        mock_symbol: MagicMock,
+        mock_get_quote: MagicMock,
+    ):
+        """Should build holdings from the selected account's open positions."""
+        mock_open_positions.return_value = [
+            {
+                "instrument": "https://instrument/hims/",
+                "quantity": "10.00000000",
+                "average_buy_price": "20.00",
+            }
+        ]
+        mock_symbol.return_value = "HIMS"
+        mock_get_quote.return_value = {"last_trade_price": "21.50"}
+
+        result = get_positions(account_number="IRA123")
+
+        assert result == {
+            "HIMS": {
+                "price": "21.50",
+                "quantity": "10.00000000",
+                "average_buy_price": "20.00",
+                "equity": "215.00",
+                "percent_change": "7.50",
+                "equity_change": "15.00",
+            }
+        }
+        mock_open_positions.assert_called_once_with(account_number="IRA123")
+        mock_build_holdings.assert_not_called()
+
 
 class TestGetPosition:
     """Tests for get_position function."""
@@ -351,6 +476,35 @@ class TestGetPosition:
         mock_get_instruments.assert_called_once_with("HIMS")
         mock_open_positions.assert_called_once_with()
         mock_get_quote.assert_called_once_with("HIMS")
+        mock_build_holdings.assert_not_called()
+
+    @patch("robinhood_mcp.tools.rh.account.build_holdings")
+    @patch("robinhood_mcp.tools.get_quote")
+    @patch("robinhood_mcp.tools.rh.account.get_open_stock_positions")
+    @patch("robinhood_mcp.tools.rh.stocks.get_instruments_by_symbols")
+    def test_forwards_account_number_to_single_position_lookup(
+        self,
+        mock_get_instruments: MagicMock,
+        mock_open_positions: MagicMock,
+        mock_get_quote: MagicMock,
+        mock_build_holdings: MagicMock,
+    ):
+        """Should search one symbol inside the selected account."""
+        mock_get_instruments.return_value = [{"url": "https://instrument/hims/"}]
+        mock_open_positions.return_value = [
+            {
+                "instrument": "https://instrument/hims/",
+                "quantity": "10.00000000",
+                "average_buy_price": "20.00",
+            }
+        ]
+        mock_get_quote.return_value = {"last_trade_price": "21.50"}
+
+        result = get_position("HIMS", account_number="IRA123")
+
+        assert result["symbol"] == "HIMS"
+        assert result["held"] is True
+        mock_open_positions.assert_called_once_with(account_number="IRA123")
         mock_build_holdings.assert_not_called()
 
     @patch("robinhood_mcp.tools.get_quote")
@@ -523,6 +677,33 @@ class TestGetDividends:
 
         assert result == expected
 
+    @patch("robinhood_mcp.tools.rh.account.get_dividends")
+    def test_filters_dividends_by_account_number(self, mock_divs: MagicMock):
+        """Should return only dividends for the selected account."""
+        mock_divs.return_value = [
+            {
+                "amount": "0.23",
+                "payable_date": "2024-02-15",
+                "account": "https://api.robinhood.com/accounts/IRA123/",
+            },
+            {
+                "amount": "0.42",
+                "payable_date": "2024-02-16",
+                "account": "https://api.robinhood.com/accounts/TAXABLE456/",
+            },
+        ]
+
+        result = get_dividends(account_number="IRA123")
+
+        assert result == [
+            {
+                "amount": "0.23",
+                "payable_date": "2024-02-15",
+                "account": "https://api.robinhood.com/accounts/IRA123/",
+            }
+        ]
+        mock_divs.assert_called_once_with()
+
 
 class TestGetOptionsPositions:
     """Tests for get_options_positions function."""
@@ -536,6 +717,16 @@ class TestGetOptionsPositions:
         result = get_options_positions()
 
         assert result == expected
+
+    @patch("robinhood_mcp.tools.rh.options.get_open_option_positions")
+    def test_forwards_account_number(self, mock_options: MagicMock):
+        """Should request option positions for the selected account."""
+        mock_options.return_value = [{"chain_symbol": "AAPL", "type": "call", "quantity": "1"}]
+
+        result = get_options_positions(account_number="IRA123")
+
+        assert result == [{"chain_symbol": "AAPL", "type": "call", "quantity": "1"}]
+        mock_options.assert_called_once_with(account_number="IRA123")
 
 
 class TestGetWatchlist:
@@ -737,6 +928,20 @@ class TestGetOrderHistory:
         get_order_history(start_date="2026-01-01")
 
         assert mock_orders.call_args.kwargs.get("start_date") == "2026-01-01"
+
+    @patch("robinhood_mcp.tools.rh.stocks.get_symbol_by_url")
+    @patch("robinhood_mcp.tools.rh.orders.get_all_stock_orders")
+    def test_account_number_forwarded_to_api(self, mock_orders: MagicMock, mock_symbol: MagicMock):
+        """account_number should be forwarded to robin_stocks order history."""
+        mock_symbol.return_value = "HIMS"
+        mock_orders.return_value = [_make_order()]
+
+        get_order_history(account_number="IRA123", start_date="2026-01-01")
+
+        assert mock_orders.call_args.kwargs == {
+            "start_date": "2026-01-01",
+            "account_number": "IRA123",
+        }
 
     @patch("robinhood_mcp.tools.rh.stocks.get_symbol_by_url")
     @patch("robinhood_mcp.tools.rh.orders.get_all_stock_orders")


### PR DESCRIPTION
## Summary
- add robinhood_get_accounts so users can discover selectable Robinhood account numbers
- add optional account_number support to account-scoped portfolio, stock position, dividend, option position, and stock order-history tools
- document account selection and update registry metadata

## Tests
- uv run --extra dev pytest -q
- uv run --extra dev ruff check .
- uv run --extra dev ruff format --check .
- git diff --check
- python3 -m json.tool server.json >/dev/null

## Risk
- No trading APIs are exposed; this stays read-only. Account-specific stock holdings use Robinhood open positions directly because robin_stocks build_holdings() does not accept account_number.